### PR TITLE
Update env.sh to work on Mac OSX

### DIFF
--- a/rl_coach/env.sh
+++ b/rl_coach/env.sh
@@ -23,13 +23,17 @@ fi
 export MARKOV_PRESET_FILE=deepracer.py
 
 # Check if the "readlink -f" command works
-if readlink -f ./env_vars.json 2>/dev/null ;
+if [[ -x $(which readlink) ]] && readlink -f ./env_vars.json >/dev/null 2>&1 ;
 then
   export LOCAL_ENV_VAR_JSON_PATH=$(readlink -f ./env_vars.json)
-else  
+elif [[ -x $(which greadlink) ]] && greadlink -f ./env_vars.json >/dev/null 2>&1 ;
+then	
   # On Macs the readlink command doesn't support the -f option, so we need to
   # use greadlink instead
   export LOCAL_ENV_VAR_JSON_PATH=$(greadlink -f ./env_vars.json)
+else
+  echo "Missing readlink and greadlink, cannot set LOCAL_ENV_VAR_JSON_PATH"
+  return 1
 fi
   
 #export LOCAL_EXTRA_DOCKER_COMPOSE_PATH=$(readlink -f ./docker_compose_extra.json)

--- a/rl_coach/env.sh
+++ b/rl_coach/env.sh
@@ -9,7 +9,27 @@ export AWS_DEFAULT_REGION=us-east-1
 export MODEL_S3_PREFIX=rl-deepracer-sagemaker
 export MODEL_S3_BUCKET=bucket
 export LOCAL=True
-export S3_ENDPOINT_URL=http://$(hostname -i):9000
+
+# Check if the "hostname -i" command works
+if hostname -i 2>/dev/null ;
+then
+  export S3_ENDPOINT_URL=http://$(hostname -i):9000  
+else  
+  # On Macs hostname doesn't support a -i option
+  IP_ADDRESS=`ifconfig | grep "inet " | grep -m 1 -Fv 127.0.0.1 | awk '{print $2}'`
+  export S3_ENDPOINT_URL=http://${IP_ADDRESS}:9000
+fi
+
 export MARKOV_PRESET_FILE=deepracer.py
-export LOCAL_ENV_VAR_JSON_PATH=$(readlink -f ./env_vars.json)
+
+# Check if the "readlink -f" command works
+if readlink -f ./env_vars.json 2>/dev/null ;
+then
+  export LOCAL_ENV_VAR_JSON_PATH=$(readlink -f ./env_vars.json)
+else  
+  # On Macs the readlink command doesn't support the -f option, so we need to
+  # use greadlink instead
+  export LOCAL_ENV_VAR_JSON_PATH=$(greadlink -f ./env_vars.json)
+fi
+  
 #export LOCAL_EXTRA_DOCKER_COMPOSE_PATH=$(readlink -f ./docker_compose_extra.json)


### PR DESCRIPTION
Fix for https://github.com/crr0004/deepracer/issues/11.

TESTING

Done on macOS Mojave 10.14.6:

```
$ cd deepracer/rl_coach/
$ env | grep S3
$ env | grep LOCAL
$ source env.sh
$ env | grep S3
MODEL_S3_BUCKET=bucket
MODEL_S3_PREFIX=rl-deepracer-sagemaker
S3_ENDPOINT_URL=http://192.168.1.207:9000
$ env | grep LOCAL
LOCAL=True
LOCAL_ENV_VAR_JSON_PATH=/Users/dj/Code/deepracer/rl_coach/env_vars.json
```